### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "petenelson/wp-cli-size",
     "description": "Database and table sizes command for WP-CLI",
+    "type": "wp-cli-package",
     "homepage": "https://github.com/petenelson/wp-cli-size",
     "license": "MIT",
     "require": {


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
